### PR TITLE
Metrics base styles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,9 +33,9 @@ const Profiles = () => (
 );
 
 const Layout = () => (
-  <div tw="font-lab-grotesque light:(bg-off-white text-darker-grey) dark:(bg-dark-grey text-lighter-grey) h-screen">
-    <nav tw="w-full fixed bottom-0">
-      <ul tw="flex flex-row">
+  <div tw="font-lab-grotesque light:(bg-off-white text-darker-grey) dark:(bg-dark-grey text-lighter-grey)">
+    <nav tw="w-full fixed bottom-0 light:(bg-off-white bg-opacity-80 backdrop-blur text-darker-grey) dark:(bg-dark-grey bg-opacity-80 backdrop-blur text-lighter-grey)">
+      <ul tw="flex flex-row pt-8 pb-8">
         <li tw="flex-1 text-center">
           <Link to="/settings">Settings</Link>
         </li>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Link, Outlet, Route, Routes } from "react-router-dom";
 import "twin.macro";
 import DemoThing from "./DemoThing";
+import Metrics from "./Metrics";
 
 const App = () => {
   return (
@@ -18,16 +19,6 @@ const App = () => {
     </Routes>
   );
 };
-
-const Metrics = () => (
-  <div>
-    <h1>Metrics here</h1>
-
-    <Link to="/test" tw="underline hover:no-underline">
-      Page with some styling examples
-    </Link>
-  </div>
-);
 
 const Settings = () => (
   <div>

--- a/src/Metrics.tsx
+++ b/src/Metrics.tsx
@@ -31,7 +31,7 @@ const data = [
 ];
 
 const Metrics = () => (
-  <div tw="p-12">
+  <div tw="p-12 h-screen">
     <header tw="pb-8">
       <h1 tw="text-3xl">Espresso</h1>
       <p tw="text-base text-medium-grey">Warming up</p>

--- a/src/Metrics.tsx
+++ b/src/Metrics.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import "twin.macro";
+
+const Metrics = () => (
+  <div tw="p-12">
+    <header tw="pb-8">
+      <h1 tw="text-3xl">Espresso</h1>
+      <p tw="text-base text-medium-grey">Warming up</p>
+    </header>
+    <Link to="#" tw="text-xl pt-8 pb-8 mb-8 border-t-2 border-b-2 border-heavy-grey flex justify-between">
+      <span>Best overall pressure</span>
+      <span>&rarr;</span>
+    </Link>
+
+    <Measurement
+      name="Metal temp"
+      measurement="56"
+      unit="℃"
+    />
+
+    <Measurement
+      name="Pressure"
+      measurement="0.0"
+      unit="bar"
+    />
+  </div>
+);
+
+const Measurement = (props) => (
+  <div tw="mb-8">
+    <h3 tw="uppercase text-xs text-medium-grey">{props.name}</h3>
+    <p tw="text-3xl">
+      <span tw="pr-2">{props.measurement}</span>
+      <span tw="text-medium-grey">{props.unit}</span>
+    </p>
+  </div>
+)
+
+export default Metrics;

--- a/src/Metrics.tsx
+++ b/src/Metrics.tsx
@@ -2,6 +2,34 @@ import React from "react";
 import { Link } from "react-router-dom";
 import "twin.macro";
 
+const data = [
+    {
+      name: "Metal Temp",
+      measurement: "56",
+      unit: "℃"
+    },
+    {
+      name: "Pressure",
+      measurement: "0.0",
+      unit: "bar"
+    },
+    {
+      name: "Flow Rate",
+      measurement: "0.0",
+      unit: "ml/s"
+    },
+    {
+      name: "Shot Time",
+      measurement: "0.0",
+      unit: "s"
+    },
+    {
+      name: "Weight",
+      measurement: "0.0",
+      unit: "g"
+    }
+];
+
 const Metrics = () => (
   <div tw="p-12">
     <header tw="pb-8">
@@ -13,17 +41,13 @@ const Metrics = () => (
       <span>&rarr;</span>
     </Link>
 
-    <Measurement
-      name="Metal temp"
-      measurement="56"
-      unit="℃"
-    />
-
-    <Measurement
-      name="Pressure"
-      measurement="0.0"
-      unit="bar"
-    />
+    { data.map( measure => (
+      <Measurement
+        name={measure.name}
+        measurement={measure.measurement}
+        unit={measure.unit}
+      />
+    )) }
   </div>
 );
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
       "lighter-grey": "#EBE8E8",
       "light-grey": "#BBBBBB",
       "medium-grey": "#757575",
+      "heavy-grey": "#404040",
       "dark-grey": "#171717",
       "darker-grey": "#1E1E1E",
       "off-black": "#010101",


### PR DESCRIPTION
### Goal

Take the Home (Metrics) view from Figma and style it up in a small, focused session:

- Style up according to Sigma, with proper sizing, spacing, and color.
- Wire up basic placeholder data
- Handle mobile view only
- Dark mode only 

### Notes

hi all! I tried to dip my toes in a small and helpful way. Broke out the Metrics view into it's own component, styled it up based on Figma, dropped in some placeholder data, and tried to keep it all tidy. Only step one of many, much more to do, eg. adjust responsiveness for tablets, handle various other states, interactivity for touches (eg. selecting profile), make sure light mode / dark mode both handled well, etc etc. 

Screenshot below:

<img width="571" alt="Screen Shot 2022-03-25 at 10 43 05 PM" src="https://user-images.githubusercontent.com/766901/160226564-eafb9f1b-7ac4-416c-aa04-b843a6dd8465.png">

feel free to completely disregard this PR, no hurt feelings here, had fun tossing this up real quick #:v: 